### PR TITLE
Use npm-sass instead of node-sass

### DIFF
--- a/app/assets/sass/app.scss
+++ b/app/assets/sass/app.scss
@@ -1,4 +1,4 @@
-@import "hof-frontend-toolkit/assets/stylesheets/app.scss";
+@import "hof-frontend-toolkit";
 
 .nav-menu {
   list-style-type: none;

--- a/package.json
+++ b/package.json
@@ -25,11 +25,10 @@
     "hof-frontend-toolkit": "^1.0.0",
     "hof-govuk-template": "^1.0.0",
     "hogan-express-strict": "^0.5.4",
-    "node-sass": "4.0.0"
+    "npm-sass": "^1.3.0"
   },
   "devDependencies": {
     "nodemon": "^1.11.0",
-    "npm-run-all": "^1.7.0",
-    "npm-sass": "^1.3.0"
+    "npm-run-all": "^1.7.0"
   }
 }


### PR DESCRIPTION
- I already did some of this before but there was some unfinished stuff here https://github.com/UKHomeOffice/centre-of-excellence/commit/b7ee307136df0eb1a4935b582cba09f60b590620

Npm-sass is better than Node-sass 
Because of the way npm installs modules in a nested tree structure, there is no reliable way to ensure the location of locally installed dependencies. In particular - modules are not necessarily installed into ./node_modules. This causes trouble when trying to use npm dependencies in sass files where --includePath ./node_modules can fail unexpectedly if a dependency is shared with an ancestor (and so installed further up the tree). Nnpm-sass resolves this